### PR TITLE
Martin build importer capability2 (work in progress)

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -78,12 +78,6 @@ func main() {
 		}
 		video.Api = &api
 		video.Id = vid
-		err = video.GetUploaderInfo()
-		if err != nil {
-			log.Println(err)
-			os.Exit(-1)
-		}
-		log.Println("uploader_url:", video.UploaderInfo["uploader_url"])
 
 		log.Println("uploading file: ", file)
 		err = video.MultipartUpload(file)

--- a/cli/main.go
+++ b/cli/main.go
@@ -13,7 +13,7 @@ func main() {
 	var err error
 	var video synq.Video
 	var (
-		c = flag.String("command", "one of: create-and-upload, details, uploader_info", "pass in command")
+		c = flag.String("command", "one of: create_and_then_multipart_upload, details, uploader_info", "pass in command")
 		a = flag.String("api_key", "", "pass the synq api key")
 		v = flag.String("video_id", "", "pass in the video id to get data about")
 		f = flag.String("file", "", "path to file you want to upload")
@@ -79,47 +79,35 @@ func main() {
 		video.Api = &api
 		video.Id = vid
 
-		log.Println("uploading file: ", file)
+		log.Printf("uploading file '%s'\n", file)
 		err = video.MultipartUpload(file)
 		if err != nil {
 			log.Println(err)
 			os.Exit(-1)
 		}
-		log.Println("uploaded file")
 
 		video, err = api.GetVideo(video.Id)
-	case "create_and_upload":
-		/*
-			if file == "" {
-				log.Println("missing argument: file")
-				os.Exit(-1)
-			}
+	case "create_and_then_multipart_upload":
+		if file == "" {
+			log.Println("missing 'file'")
+			os.Exit(-1)
+		}
 
-			log.Println("creating new video")
-			video, err = api.Create()
-			if err != nil {
-				log.Println(err)
-				os.Exit(-1)
-			}
-			log.Println("created video with video_id", video.Id)
+		log.Printf("Creating new video")
+		video, err = api.Create()
+		if err != nil {
+			log.Println(err)
+			os.Exit(-1)
+		}
 
-			log.Printf("uploading file %q\n", file)
-			f, err := os.Open(file)
-			defer f.Close()
-			if err != nil {
-				log.Println(err)
-				os.Exit(-1)
-			}
+		log.Printf("uploading file '%s'\n", file)
+		err = video.MultipartUpload(file)
+		if err != nil {
+			log.Println(err)
+			os.Exit(-1)
+		}
 
-			err = video.MultipartUpload(f)
-			if err != nil {
-				log.Println(err)
-				os.Exit(-1)
-			}
-			log.Println("uploaded file")
-
-			video, err = api.GetVideo(video.Id)
-		*/
+		video, err = api.GetVideo(video.Id)
 	default:
 		err = errors.New("unknown command " + cmd)
 	}

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -251,7 +251,7 @@ func multipartUpload(body io.Reader, acl, awsAccessKeyId, bucket, contentType, k
 	svc := s3.New(sess)
 
 	// sign handler
-	signer := makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token, video_id)
+	signer := MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token, video_id)
 	svc.Handlers.Sign.PushBack(signer)
 
 	// s3manager uploader

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -9,19 +9,38 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	//"os"
-	//"time"
+	"time"
 
-	//"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
+// These Amazon Web Services credentials are provided to the AWS SDK, which is
+// used to upload content in multiple parts. There is no IAM user with these
+// credentials; they are supplied because the AWS SDK requires some credentials
+// to attempt to start uploading. This package replaces the AWS SDK's request
+// signing method with its own method.
+const multipartUploadAwsAccessKeyId = "AAAAAAAAAAAAAAAAAAAA"
+const multipartUploadAwsSecretAccessKey = "ssssssssssssssssssssssssssssssssssssssss"
+
+// TODO(mastensg): Determine region from bucket, or /v1/video/uploader
+const multipartUploadS3BucketRegion = "us-east-1"
+
 // UploaderSignatureUrlFormat is a printf format string which is used when
 // signing multipart upload requests.
+// TODO(mastensg): Determine this format (or at least prefix) at runtime, from
+// the Synq HTTP API.
 const UploaderSignatureUrlFormat = "https://uploader.synq.fm/uploader/signature/%s?token=%s"
+
+// UploaderSignatureRequest is the request that is sent when using the
+// embeddable web uploader's request signing service.
+type UploaderSignatureRequest struct {
+	Headers string `json:"headers"`
+}
 
 // UploaderSignatureResponse is the response that is received when using the
 // embeddable web uploader's request signing service.
@@ -31,41 +50,52 @@ type UploaderSignatureResponse struct {
 
 // UploaderSignature uses the backend of the embeddable web uploader to sign
 // multipart upload requests.
-func UploaderSignature(url_fmt, video_id, token string, payload []byte) ([]byte, error) {
+func UploaderSignature(url_fmt, video_id, token, headers string) ([]byte, error) {
 	url := fmt.Sprintf(url_fmt, video_id, token)
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(payload))
+	// construct request body
+	reqStruct := UploaderSignatureRequest{Headers: headers}
+	reqBody, err := json.Marshal(reqStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	// perform request
+	resp, err := http.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	// read response
+	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
 
-	type responseBody struct {
-		Signature string `json:"signature"`
-	}
-
-	rb := responseBody{}
-	err = json.Unmarshal(body, &rb)
+	// parse response
+	respStruct := UploaderSignatureResponse{}
+	err = json.Unmarshal(respBody, &respStruct)
 	if err != nil {
 		return nil, err
 	}
 
-	return []byte(rb.Signature), nil
+	return []byte(respStruct.Signature), nil
 }
 
-// tokenOfUploaderURL parses an uploader URL string, and returns its token parameter.
+// tokenOfUploaderURL parses an uploader URL string, and returns its token
+// parameter.
 //
 // Example:
-//         token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/00000000000000000000000000000000?token=11111111111111111111111111111111")
+//         const u = "https://uploader.synq.fm/uploader/" +
+//         "00000000000000000000000000000000" +
+//         "?token=11111111111111111111111111111111"
+//
+//         token, err := tokenOfUploaderURL(u)
 //         if err != nil {
 //                 log.Fatal(err)
 //         }
-//         fmt.Println(token)
+//         fmt.Println(token) // prints 11111111111111111111111111111111
 func tokenOfUploaderURL(uploaderURL string) (string, error) {
 	u, err := url.Parse(uploaderURL)
 	if err != nil {
@@ -105,8 +135,86 @@ func tokenOfUploaderURL(uploaderURL string) (string, error) {
 //         svc.Handlers.Sign.PushBack(signer)
 //
 //         // S3 requests are now signed by signer().
-func makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, uploaderURL string) func(r *request.Request) {
+func makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token, video_id string) func(r *request.Request) {
 	signer := func(r *request.Request) {
+		hr := r.HTTPRequest
+
+		// rewrite the X-Amz-Date header into the format that
+		// https://uploader.synq.fm/uploader/signature expects
+		{
+			x_amz_date_in := hr.Header.Get("X-Amz-Date")
+			if x_amz_date_in == "" {
+				return // TODO(mastensg): how to report errors from handlers?
+			}
+			x_amz_date_t, err := time.Parse("20060102T150405Z", x_amz_date_in)
+			if err != nil {
+				return // TODO(mastensg): how to report errors from handlers?
+			}
+			x_amz_date := x_amz_date_t.Format("Mon, 2 Jan 2006 15:04:05 MST")
+			delete(hr.Header, "X-Amz-Date") // TODO(mastensg): enough to just set and not delete?
+			hr.Header.Set("X-Amz-Date", x_amz_date)
+		}
+
+		x_amz_date := hr.Header.Get("X-Amz-Date")
+
+		// extract url query parameters and http headers in the formats
+		// that https://uploader.synq.fm/uploader/signature expects
+		query := hr.URL.Path
+		headers := ""
+		if hr.URL.RawQuery == "uploads=" {
+			// Initiate multi-part upload
+			query += "?uploads"
+
+			// TODO(mastensg): parameterize bucket name, content-type, acl
+			headers = fmt.Sprintf("%s\n\n%s\n\n%s\nx-amz-date:%s\n/synqfm%s",
+				hr.Method,
+				"video/mp4",
+				"x-amz-acl:public-read",
+				x_amz_date,
+				query,
+			)
+		} else if hr.Method == "PUT" {
+			// Upload one part
+			query += "?" + hr.URL.RawQuery
+
+			// TODO(mastensg): parameterize bucket name
+			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/synqfm%s",
+				hr.Method,
+				"",
+				x_amz_date,
+				query,
+			)
+		} else if hr.Method == "POST" {
+			// Finish multi-part upload
+			query += "?" + hr.URL.RawQuery
+
+			// TODO(mastensg): parameterize bucket name, content-type(?)
+			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/synqfm%s",
+				hr.Method,
+				"application/xml; charset=UTF-8",
+				x_amz_date,
+				query,
+			)
+
+			// TODO(mastensg): the content-type header set by
+			// aws-sdk-go is not exactly the one expected by
+			// uploader/signature, maybe
+			hr.Header.Set("Content-Type", "application/xml; charset=UTF-8")
+		} else {
+			// Unknown request type
+			return // TODO(mastensg): how to report errors from handlers?
+		}
+
+		signature, err := UploaderSignature(UploaderSignatureUrlFormat, video_id, token, headers)
+		if err != nil {
+			return // TODO(mastensg): how to report errors from handlers?
+		}
+
+		// rewrite authorization header(s)
+		delete(hr.Header, "X-Amz-Content-Sha256") //TODO(mastensg): can this be left in?
+		delete(hr.Header, "Authorization")
+		authorization := fmt.Sprintf("AWS %s:%s", awsAccessKeyId, signature)
+		hr.Header.Set("Authorization", authorization)
 	}
 
 	return signer
@@ -118,19 +226,31 @@ func makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, up
 //
 // This is the internal function to make uploads, which is called by the public
 // MultipartUpload. This function uses s3manager from aws-sdk-go to upload.
-func multipartUpload(body io.Reader, acl, awsAccessKeyId, bucket, contentType, key, uploaderURL string) (*s3manager.UploadOutput, error) {
+func multipartUpload(body io.Reader, acl, awsAccessKeyId, bucket, contentType, key, uploaderURL, video_id string) (*s3manager.UploadOutput, error) {
 	token, err := tokenOfUploaderURL(uploaderURL)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(token)
 
-	sess := session.Must(session.NewSession())
+	// credentials
+	provider := credentials.StaticProvider{}
+	provider.Value.AccessKeyID = multipartUploadAwsAccessKeyId
+	provider.Value.SecretAccessKey = multipartUploadAwsSecretAccessKey
+	credentials := credentials.NewCredentials(&provider)
+
+	// session
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credentials,
+		Region:      aws.String(multipartUploadS3BucketRegion),
+	})
+	if err != nil {
+		return nil, err
+	}
 
 	svc := s3.New(sess)
 
 	// sign handler
-	signer := makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, uploaderURL)
+	signer := makeMultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token, video_id)
 	svc.Handlers.Sign.PushBack(signer)
 
 	// s3manager uploader

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -66,6 +66,8 @@ func UploaderSignature(url_fmt, video_id, token, headers string) ([]byte, error)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		// TODO(mastensg): report status and maybe body
+		// TODO(mastensg): handle known error responses specifically
 		return nil, errors.New("HTTP response status not OK.")
 	}
 

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -65,6 +65,10 @@ func UploaderSignature(url_fmt, video_id, token, headers string) ([]byte, error)
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("HTTP response status not OK.")
+	}
+
 	// read response
 	respBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -279,19 +279,18 @@ func MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token,
 		} else if hr.Method == "POST" {
 			// Finish multi-part upload
 
-			// TODO(mastensg): parameterize content-type(?)
-			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/%s%s",
-				hr.Method,
-				"application/xml; charset=UTF-8",
-				x_amz_date,
-				bucket,
-				hr.URL.Path+"?"+hr.URL.RawQuery,
-			)
-
 			// TODO(mastensg): the content-type header set by
 			// aws-sdk-go is not exactly the one expected by
 			// uploader/signature, maybe
 			hr.Header.Set("Content-Type", "application/xml; charset=UTF-8")
+
+			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/%s%s",
+				hr.Method,
+				hr.Header.Get("Content-Type"),
+				x_amz_date,
+				bucket,
+				hr.URL.Path+"?"+hr.URL.RawQuery,
+			)
 		} else {
 			// Unknown request type
 			return // TODO(mastensg): how to report errors from handlers?

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -302,7 +302,7 @@ func MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token,
 		}
 
 		// rewrite authorization header(s)
-		delete(hr.Header, "X-Amz-Content-Sha256") // TODO(mastensg): can this be left in?
+		delete(hr.Header, "X-Amz-Content-Sha256")
 		delete(hr.Header, "Authorization")
 		authorization := fmt.Sprintf("AWS %s:%s", awsAccessKeyId, signature)
 		hr.Header.Set("Authorization", authorization)

--- a/synq/multipart_upload.go
+++ b/synq/multipart_upload.go
@@ -258,11 +258,10 @@ func MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token,
 		if hr.URL.RawQuery == "uploads=" {
 			// Initiate multi-part upload
 
-			// TODO(mastensg): parameterize bucket name, content-type, acl
-			headers = fmt.Sprintf("%s\n\n%s\n\n%s\nx-amz-date:%s\n/%s%s",
+			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-acl:%s\nx-amz-date:%s\n/%s%s",
 				hr.Method,
-				"video/mp4",
-				"x-amz-acl:public-read",
+				contentType,
+				acl,
 				x_amz_date,
 				bucket,
 				hr.URL.Path+"?uploads",
@@ -270,7 +269,6 @@ func MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token,
 		} else if hr.Method == "PUT" {
 			// Upload one part
 
-			// TODO(mastensg): parameterize bucket name
 			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/%s%s",
 				hr.Method,
 				"",
@@ -281,7 +279,7 @@ func MultipartUploadSigner(acl, awsAccessKeyId, bucket, contentType, key, token,
 		} else if hr.Method == "POST" {
 			// Finish multi-part upload
 
-			// TODO(mastensg): parameterize bucket name, content-type(?)
+			// TODO(mastensg): parameterize content-type(?)
 			headers = fmt.Sprintf("%s\n\n%s\n\nx-amz-date:%s\n/%s%s",
 				hr.Method,
 				"application/xml; charset=UTF-8",

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -312,6 +312,31 @@ func TestUploaderSignatureUrlFormatOfTestServerUrl(t *testing.T) {
 func TestUploaderSignature(t *testing.T) {
 	assert := assert.New(t)
 
+	// no server
+	{
+		uf := uploaderSignatureUrlFormatOfTestServerUrl("http://0.0.0.0:0")
+
+		const video_id = "e3c71a23462f07fea2ef317dcd3b7a9b"
+		const token = "568575f9c000b533292adc88f5a2321a"
+		const headers = `POST
+
+video/mp4
+
+x-amz-acl:public-read
+x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
+/synqfm/projects/00/00/00000000000000000000000000000000/uploads/videos/e3/c7/e3c71a23462f07fea2ef317dcd3b7a9b.mp4?uploads`
+
+		signature, err := UploaderSignature(uf, video_id, token, headers)
+
+		const expectedError = `Post http://0.0.0.0:0/uploader/signature/` +
+			`e3c71a23462f07fea2ef317dcd3b7a9b?token=568575f9c000b533292adc88f5a2321a:` +
+			` dial tcp 0.0.0.0:0: getsockopt: connection refused`
+
+		// TODO(mastensg): check errors by some other method than string matching
+		assert.Equal([]byte(nil), signature)
+		assert.Equal(expectedError, err.Error())
+	}
+
 	// always internal server error
 	{
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -333,6 +358,7 @@ x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
 
 		signature, err := UploaderSignature(uf, video_id, token, headers)
 
+		// TODO(mastensg): check errors by some other method than string matching
 		assert.Equal([]byte(nil), signature)
 		assert.Equal("HTTP response status not OK.", err.Error())
 	}

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -162,7 +162,7 @@ func TestBucketOfUploadAction(t *testing.T) {
 
 	// not "com"
 	{
-		bucket, err := regionOfUploadAction("https://bucket.s3.amazonaws.org/")
+		bucket, err := bucketOfUploadAction("https://bucket.s3.amazonaws.org/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", bucket)
 	}
@@ -219,7 +219,7 @@ func TestRegionOfUploadAction(t *testing.T) {
 
 	// invalid region
 	{
-		region, err := bucketOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
+		region, err := regionOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
 		assert.NotEqual(nil, err)
 		assert.Equal("", region)
 	}

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -362,4 +362,30 @@ x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
 		assert.Equal([]byte(nil), signature)
 		assert.Equal("HTTP response status not OK.", err.Error())
 	}
+
+	// return something which is not json
+	{
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "not json")
+		}))
+		defer ts.Close()
+
+		uf := uploaderSignatureUrlFormatOfTestServerUrl(ts.URL)
+
+		const video_id = "e3c71a23462f07fea2ef317dcd3b7a9b"
+		const token = "568575f9c000b533292adc88f5a2321a"
+		const headers = `POST
+
+video/mp4
+
+x-amz-acl:public-read
+x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
+/synqfm/projects/00/00/00000000000000000000000000000000/uploads/videos/e3/c7/e3c71a23462f07fea2ef317dcd3b7a9b.mp4?uploads`
+
+		signature, err := UploaderSignature(uf, video_id, token, headers)
+
+		// TODO(mastensg): check errors by some other method than string matching
+		assert.Equal([]byte(nil), signature)
+		assert.Equal("invalid character 'o' in literal null (expecting 'u')", err.Error())
+	}
 }

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -111,25 +111,39 @@ func TestBucketOfUploadAction(t *testing.T) {
 		assert.Equal("not-https", bucket)
 	}
 
+	// not the special "us-east-1" region
+	{
+		bucket, err := bucketOfUploadAction("https://a-bucket-in-another-region.s3-eu-west-1.amazonaws.com")
+		assert.Equal(nil, err)
+		assert.Equal("a-bucket-in-another-region", bucket)
+	}
+
+	// invalid region
+	{
+		bucket, err := bucketOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
+		assert.NotEqual(nil, err)
+		assert.Equal("", bucket)
+	}
+
 	// another kind of url
 	{
 		bucket, err := bucketOfUploadAction("https://uploader.synq.fm")
 		assert.NotEqual(nil, err)
-		assert.NotEqual("uploader", bucket)
+		assert.Equal("", bucket)
 	}
 
 	// yet another kind of url
 	{
 		bucket, err := bucketOfUploadAction("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=not32characters")
 		assert.NotEqual(nil, err)
-		assert.NotEqual("uploader", bucket)
+		assert.Equal("", bucket)
 	}
 
 	// no bucket, and the bucket that is not there is not named "s3"
 	{
 		bucket, err := bucketOfUploadAction("https://s3.amazonaws.com")
 		assert.NotEqual(nil, err)
-		assert.NotEqual("s3", bucket)
+		assert.Equal("", bucket)
 	}
 
 	// any non-empty bucket name
@@ -144,9 +158,85 @@ func TestBucketOfUploadAction(t *testing.T) {
 
 				return bucket == v && err == nil
 			},
-			gen.AnyString().SuchThat(
-				func(v string) bool { return v != "" },
-			),
+			gen.RegexMatch("^[a-z][a-z0-9_-]+$"),
+		))
+
+		p.TestingRun(t)
+	}
+}
+
+func TestRegionOfUploadAction(t *testing.T) {
+	assert := assert.New(t)
+
+	// real example
+	{
+		region, err := regionOfUploadAction("https://synqfm.s3.amazonaws.com")
+		assert.Equal(nil, err)
+		assert.Equal("us-east-1", region)
+	}
+
+	// another region
+	{
+		region, err := regionOfUploadAction("https://a-bucket.s3-us-west-2.amazonaws.com")
+		assert.Equal(nil, err)
+		assert.Equal("us-west-2", region)
+	}
+
+	// yet another region with slash at the end
+	{
+		region, err := regionOfUploadAction("https://some-bucket.s3-ap-south-1.amazonaws.com/")
+		assert.Equal(nil, err)
+		assert.Equal("ap-south-1", region)
+	}
+
+	// not https but http
+	{
+		region, err := regionOfUploadAction("http://not-https.s3-sa-east-1.amazonaws.com")
+		assert.Equal(nil, err)
+		assert.Equal("sa-east-1", region)
+	}
+
+	// invalid region
+	{
+		region, err := bucketOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// another kind of url
+	{
+		region, err := regionOfUploadAction("https://player.synq.fm")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// yet another kind of url
+	{
+		region, err := regionOfUploadAction("https://player.synq.fm/embed/55d4062f99454c9fb21e5186a09c2115")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// no "s3", and the region that is not there is not named "us-east-1"
+	{
+		region, err := regionOfUploadAction("https://bucket.amazonaws.com")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// any non-empty region name
+	{
+		p := gopter.NewProperties(nil)
+
+		p.Property("extract any region name", prop.ForAll(
+			func(v string) bool {
+				const format = "https://bucket.s3-%s.amazonaws.com"
+
+				region, err := regionOfUploadAction(fmt.Sprintf(format, v))
+
+				return region == v && err == nil
+			},
+			gen.RegexMatch("^[a-z]+-[a-z]-[0-9]+$"),
 		))
 
 		p.TestingRun(t)

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -12,74 +12,6 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestTokenOfUploaderURL(t *testing.T) {
-	assert := assert.New(t)
-
-	// real example
-	{
-		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
-		assert.Equal(nil, err)
-		assert.Equal("b7230fea53d525948f33abf5f4b893f5", token)
-	}
-
-	// non-uuid token
-	{
-		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=not32characters")
-		assert.Equal(nil, err)
-		assert.Equal("not32characters", token)
-	}
-
-	// no url scheme
-	{
-		token, err := tokenOfUploaderURL("://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
-		assert.NotEqual(nil, err)
-		assert.Equal("", token)
-	}
-
-	// no query
-	{
-		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115")
-		assert.NotEqual(nil, err)
-		assert.Equal("", token)
-	}
-
-	// no "token" parameter
-	{
-		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?notoken=notoken")
-		assert.NotEqual(nil, err)
-		assert.Equal("", token)
-	}
-
-	// any non-empty token string
-	{
-		p := gopter.NewProperties(nil)
-
-		p.Property("extract any token string", prop.ForAll(
-			func(v string) bool {
-				const base = "https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115"
-
-				u, err := url.Parse(base)
-				if err != nil {
-					panic(err)
-				}
-
-				values := url.Values{}
-				values.Set("token", v)
-				u.RawQuery = values.Encode()
-
-				token, err := tokenOfUploaderURL(u.String())
-
-				return token == v && err == nil
-			},
-			gen.AnyString().SuchThat(
-				func(v string) bool { return v != "" },
-			),
-		))
-
-		p.TestingRun(t)
-	}
-}
-
 func TestBucketOfUploadAction(t *testing.T) {
 	assert := assert.New(t)
 
@@ -286,6 +218,74 @@ func TestRegionOfUploadAction(t *testing.T) {
 				return region == v && err == nil
 			},
 			gen.RegexMatch("^[a-z]+-[a-z]-[0-9]+$"),
+		))
+
+		p.TestingRun(t)
+	}
+}
+
+func TestTokenOfUploaderURL(t *testing.T) {
+	assert := assert.New(t)
+
+	// real example
+	{
+		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
+		assert.Equal(nil, err)
+		assert.Equal("b7230fea53d525948f33abf5f4b893f5", token)
+	}
+
+	// non-uuid token
+	{
+		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=not32characters")
+		assert.Equal(nil, err)
+		assert.Equal("not32characters", token)
+	}
+
+	// no url scheme
+	{
+		token, err := tokenOfUploaderURL("://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
+		assert.NotEqual(nil, err)
+		assert.Equal("", token)
+	}
+
+	// no query
+	{
+		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115")
+		assert.NotEqual(nil, err)
+		assert.Equal("", token)
+	}
+
+	// no "token" parameter
+	{
+		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?notoken=notoken")
+		assert.NotEqual(nil, err)
+		assert.Equal("", token)
+	}
+
+	// any non-empty token string
+	{
+		p := gopter.NewProperties(nil)
+
+		p.Property("extract any token string", prop.ForAll(
+			func(v string) bool {
+				const base = "https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115"
+
+				u, err := url.Parse(base)
+				if err != nil {
+					panic(err)
+				}
+
+				values := url.Values{}
+				values.Set("token", v)
+				u.RawQuery = values.Encode()
+
+				token, err := tokenOfUploaderURL(u.String())
+
+				return token == v && err == nil
+			},
+			gen.AnyString().SuchThat(
+				func(v string) bool { return v != "" },
+			),
 		))
 
 		p.TestingRun(t)

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -153,6 +153,20 @@ func TestBucketOfUploadAction(t *testing.T) {
 		assert.Equal("", bucket)
 	}
 
+	// not "amazonaws"
+	{
+		bucket, err := bucketOfUploadAction("https://s3.amazon.com/")
+		assert.NotEqual(nil, err)
+		assert.Equal("", bucket)
+	}
+
+	// not "com"
+	{
+		bucket, err := bucketOfUploadAction("https://s3.amazon.com/")
+		assert.NotEqual(nil, err)
+		assert.Equal("", bucket)
+	}
+
 	// any non-empty bucket name
 	{
 		p := gopter.NewProperties(nil)
@@ -234,6 +248,20 @@ func TestRegionOfUploadAction(t *testing.T) {
 	// invalid url
 	{
 		region, err := regionOfUploadAction("https://s3.amazonaws.com/%")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// not "amazonaws"
+	{
+		region, err := regionOfUploadAction("https://s3.amazon.com/")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
+	// not "com"
+	{
+		region, err := regionOfUploadAction("https://s3.amazon.com/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", region)
 	}

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -388,4 +388,34 @@ x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
 		assert.Equal([]byte(nil), signature)
 		assert.Equal("invalid character 'o' in literal null (expecting 'u')", err.Error())
 	}
+
+	// return signature
+	{
+		const video_id = "e3c71a23462f07fea2ef317dcd3b7a9b"
+		const token = "568575f9c000b533292adc88f5a2321a"
+		const headers = `POST
+
+video/mp4
+
+x-amz-acl:public-read
+x-amz-date:Fri, 30 Jun 2017 14:50:33 UTC
+/synqfm/projects/20/fc/20fc57c626dc489ea285493b3813a0b5/uploads/videos/58/70/58705c8fcb054fb68fe85b61ab4f17af.mp4?uploads`
+		const request = `{"headers":"POST\n\nvideo/mp4\n\nx-amz-acl:public-read\nx-amz-date:Fri,` +
+			` 30 Jun 2017 14:50:33 UTC\n/synqfm/projects/20/fc/20fc57c626dc489ea285493b3813a0b5` +
+			`/uploads/videos/58/70/58705c8fcb054fb68fe85b61ab4f17af.mp4?uploads"}`
+		const expectedSignature = "/0OolBcoDZ95IbeDPMt5P+3kCnc="
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			response := fmt.Sprintf(`{"signature":"%s"}`, expectedSignature)
+			fmt.Fprint(w, response)
+		}))
+		defer ts.Close()
+
+		uf := uploaderSignatureUrlFormatOfTestServerUrl(ts.URL)
+
+		signature, err := UploaderSignature(uf, video_id, token, headers)
+
+		assert.Equal([]byte(expectedSignature), signature)
+		assert.Equal(nil, err)
+	}
 }

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -389,6 +389,32 @@ x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
 		assert.Equal("invalid character 'o' in literal null (expecting 'u')", err.Error())
 	}
 
+	// empty response
+	{
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "")
+		}))
+		defer ts.Close()
+
+		uf := uploaderSignatureUrlFormatOfTestServerUrl(ts.URL)
+
+		const video_id = "e3c71a23462f07fea2ef317dcd3b7a9b"
+		const token = "568575f9c000b533292adc88f5a2321a"
+		const headers = `POST
+
+video/mp4
+
+x-amz-acl:public-read
+x-amz-date:Fri, 30 Jun 2017 14:03:55 UTC
+/synqfm/projects/00/00/00000000000000000000000000000000/uploads/videos/e3/c7/e3c71a23462f07fea2ef317dcd3b7a9b.mp4?uploads`
+
+		signature, err := UploaderSignature(uf, video_id, token, headers)
+
+		// TODO(mastensg): check errors by some other method than string matching
+		assert.Equal([]byte(nil), signature)
+		assert.Equal("unexpected end of JSON input", err.Error())
+	}
+
 	// return signature
 	{
 		const video_id = "e3c71a23462f07fea2ef317dcd3b7a9b"

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -20,84 +20,84 @@ func TestBucketOfUploadAction(t *testing.T) {
 	// real example
 	{
 		bucket, err := bucketOfUploadAction("https://synqfm.s3.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("synqfm", bucket)
 	}
 
 	// another bucket
 	{
 		bucket, err := bucketOfUploadAction("https://another-bucket.s3.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("another-bucket", bucket)
 	}
 
 	// yet another bucket with slash at the end
 	{
 		bucket, err := bucketOfUploadAction("https://yet-another-bucket.s3.amazonaws.com/")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("yet-another-bucket", bucket)
 	}
 
 	// not https but http
 	{
 		bucket, err := bucketOfUploadAction("http://not-https.s3.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("not-https", bucket)
 	}
 
 	// not the special "us-east-1" region
 	{
 		bucket, err := bucketOfUploadAction("https://a-bucket-in-another-region.s3-eu-west-1.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("a-bucket-in-another-region", bucket)
 	}
 
 	// invalid region
 	{
 		bucket, err := bucketOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// another kind of url
 	{
 		bucket, err := bucketOfUploadAction("https://uploader.synq.fm")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// yet another kind of url
 	{
 		bucket, err := bucketOfUploadAction("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=not32characters")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// no bucket, and the bucket that is not there is not named "s3"
 	{
 		bucket, err := bucketOfUploadAction("https://s3.amazonaws.com")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// invalid url
 	{
 		bucket, err := bucketOfUploadAction("https://bucket.s3.amazonaws.com/%")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// not "amazonaws"
 	{
 		bucket, err := bucketOfUploadAction("https://bucket.s3.amazon.com/")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
 	// not "com"
 	{
 		bucket, err := bucketOfUploadAction("https://bucket.s3.amazonaws.org/")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", bucket)
 	}
 
@@ -126,84 +126,84 @@ func TestRegionOfUploadAction(t *testing.T) {
 	// real example
 	{
 		region, err := regionOfUploadAction("https://synqfm.s3.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("us-east-1", region)
 	}
 
 	// another region
 	{
 		region, err := regionOfUploadAction("https://a-bucket.s3-us-west-2.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("us-west-2", region)
 	}
 
 	// yet another region with slash at the end
 	{
 		region, err := regionOfUploadAction("https://some-bucket.s3-ap-south-1.amazonaws.com/")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("ap-south-1", region)
 	}
 
 	// not https but http
 	{
 		region, err := regionOfUploadAction("http://not-https.s3-sa-east-1.amazonaws.com")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("sa-east-1", region)
 	}
 
 	// invalid region
 	{
 		region, err := regionOfUploadAction("https://invalid-region.not-s3-eu-west-1.amazonaws.com")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// another kind of url
 	{
 		region, err := regionOfUploadAction("https://player.synq.fm")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// yet another kind of url
 	{
 		region, err := regionOfUploadAction("https://player.synq.fm/embed/55d4062f99454c9fb21e5186a09c2115")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// no "s3", and the region that is not there is not named "us-east-1"
 	{
 		region, err := regionOfUploadAction("https://bucket.amazonaws.com")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// invalid url
 	{
 		region, err := regionOfUploadAction("https://bucket.s3.amazonaws.com/%")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// not "amazonaws"
 	{
 		region, err := regionOfUploadAction("https://bucket.s3.amazon.com/")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// not "com"
 	{
 		region, err := regionOfUploadAction("https://bucket.s3.amazonaws.org/")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
 	// start with "s3", but not with "s3-"
 	{
 		region, err := regionOfUploadAction("https://invalid-region.s3eu-west-1.amazonaws.com")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", region)
 	}
 
@@ -232,35 +232,35 @@ func TestTokenOfUploaderURL(t *testing.T) {
 	// real example
 	{
 		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("b7230fea53d525948f33abf5f4b893f5", token)
 	}
 
 	// non-uuid token
 	{
 		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=not32characters")
-		assert.Equal(nil, err)
+		assert.Nil(err)
 		assert.Equal("not32characters", token)
 	}
 
 	// no url scheme
 	{
 		token, err := tokenOfUploaderURL("://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?token=b7230fea53d525948f33abf5f4b893f5")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", token)
 	}
 
 	// no query
 	{
 		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", token)
 	}
 
 	// no "token" parameter
 	{
 		token, err := tokenOfUploaderURL("https://uploader.synq.fm/uploader/55d4062f99454c9fb21e5186a09c2115?notoken=notoken")
-		assert.NotEqual(nil, err)
+		assert.NotNil(err)
 		assert.Equal("", token)
 	}
 
@@ -416,6 +416,6 @@ x-amz-date:Fri, 30 Jun 2017 14:50:33 UTC
 		signature, err := UploaderSignature(uf, video_id, token, headers)
 
 		assert.Equal([]byte(expectedSignature), signature)
-		assert.Equal(nil, err)
+		assert.Nil(err)
 	}
 }

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -266,6 +266,13 @@ func TestRegionOfUploadAction(t *testing.T) {
 		assert.Equal("", region)
 	}
 
+	// start with "s3", but not with "s3-"
+	{
+		region, err := regionOfUploadAction("https://invalid-region.s3eu-west-1.amazonaws.com")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
 	// any non-empty region name
 	{
 		p := gopter.NewProperties(nil)

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -146,6 +146,13 @@ func TestBucketOfUploadAction(t *testing.T) {
 		assert.Equal("", bucket)
 	}
 
+	// invalid url
+	{
+		bucket, err := bucketOfUploadAction("https:/s3.amazonaws.com")
+		assert.NotEqual(nil, err)
+		assert.Equal("", bucket)
+	}
+
 	// any non-empty bucket name
 	{
 		p := gopter.NewProperties(nil)

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -148,7 +148,7 @@ func TestBucketOfUploadAction(t *testing.T) {
 
 	// invalid url
 	{
-		bucket, err := bucketOfUploadAction("https:/s3.amazonaws.com")
+		bucket, err := bucketOfUploadAction("https://s3.amazonaws.com/%")
 		assert.NotEqual(nil, err)
 		assert.Equal("", bucket)
 	}

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -231,6 +231,13 @@ func TestRegionOfUploadAction(t *testing.T) {
 		assert.Equal("", region)
 	}
 
+	// invalid url
+	{
+		region, err := regionOfUploadAction("https://s3.amazonaws.com/%")
+		assert.NotEqual(nil, err)
+		assert.Equal("", region)
+	}
+
 	// any non-empty region name
 	{
 		p := gopter.NewProperties(nil)

--- a/synq/multipart_upload_test.go
+++ b/synq/multipart_upload_test.go
@@ -148,21 +148,21 @@ func TestBucketOfUploadAction(t *testing.T) {
 
 	// invalid url
 	{
-		bucket, err := bucketOfUploadAction("https://s3.amazonaws.com/%")
+		bucket, err := bucketOfUploadAction("https://bucket.s3.amazonaws.com/%")
 		assert.NotEqual(nil, err)
 		assert.Equal("", bucket)
 	}
 
 	// not "amazonaws"
 	{
-		bucket, err := bucketOfUploadAction("https://s3.amazon.com/")
+		bucket, err := bucketOfUploadAction("https://bucket.s3.amazon.com/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", bucket)
 	}
 
 	// not "com"
 	{
-		bucket, err := bucketOfUploadAction("https://s3.amazon.com/")
+		bucket, err := regionOfUploadAction("https://bucket.s3.amazonaws.org/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", bucket)
 	}
@@ -247,21 +247,21 @@ func TestRegionOfUploadAction(t *testing.T) {
 
 	// invalid url
 	{
-		region, err := regionOfUploadAction("https://s3.amazonaws.com/%")
+		region, err := regionOfUploadAction("https://bucket.s3.amazonaws.com/%")
 		assert.NotEqual(nil, err)
 		assert.Equal("", region)
 	}
 
 	// not "amazonaws"
 	{
-		region, err := regionOfUploadAction("https://s3.amazon.com/")
+		region, err := regionOfUploadAction("https://bucket.s3.amazon.com/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", region)
 	}
 
 	// not "com"
 	{
-		region, err := regionOfUploadAction("https://s3.amazon.com/")
+		region, err := regionOfUploadAction("https://bucket.s3.amazonaws.org/")
 		assert.NotEqual(nil, err)
 		assert.Equal("", region)
 	}

--- a/synq/video.go
+++ b/synq/video.go
@@ -253,16 +253,18 @@ func (v *Video) MultipartUpload(fileName string) error {
 		return errors.New("file '" + fileName + "' does not exist")
 	}
 
+	// extract upload action url
+	actionURL := v.UploadInfo.url()
+
 	// extract uploader url
 	uploaderURL := v.UploaderInfo.url()
 
 	// multipartUploadWithUploaderURL
 	acl := v.UploadInfo["acl"]
 	awsAccessKeyId := v.UploadInfo["AWSAccessKeyId"]
-	bucket := "synqfm" // TODO(mastensg): bucket from v.UploadInfo["action"]
 	contentType := v.UploadInfo["Content-Type"]
 	key := v.UploadInfo["key"]
-	if _, err := multipartUpload(f, acl, awsAccessKeyId, bucket, contentType, key, uploaderURL, v.Id); err != nil {
+	if _, err := multipartUpload(f, acl, actionURL, awsAccessKeyId, contentType, key, uploaderURL, v.Id); err != nil {
 		return err
 	}
 

--- a/synq/video.go
+++ b/synq/video.go
@@ -262,7 +262,7 @@ func (v *Video) MultipartUpload(fileName string) error {
 	bucket := "synqfm" // TODO(mastensg): bucket from v.UploadInfo["action"]
 	contentType := v.UploadInfo["Content-Type"]
 	key := v.UploadInfo["key"]
-	if _, err := multipartUpload(f, acl, awsAccessKeyId, bucket, contentType, key, uploaderURL); err != nil {
+	if _, err := multipartUpload(f, acl, awsAccessKeyId, bucket, contentType, key, uploaderURL, v.Id); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
please do not merge. i would like this implementation, and tests to the extent that they exist, to be critiqued

i have added the needed functionality for  #12 build importer capability, but perhaps not enough tests. there are tests for functions which parse things, but no testing of interactions with http servers

again, i have added dependencies on [aws-sdk-go](https://github.com/aws/aws-sdk-go) for its s3manager which handles multipart uploading, and on [gopter](https://github.com/leanovate/gopter) for property-based testing