### PR TITLE
create a LoadVideo/LoadVideoByQuery helper functions inside synq SDK instead

### DIFF
--- a/helper/load.go
+++ b/helper/load.go
@@ -2,7 +2,6 @@ package helper
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -48,8 +47,19 @@ func LoadVideosByQuery(query, name string, c common.Cacheable, api synq.Api) (vi
 	return videos, err
 }
 
+// fow now, the query will be the account id
 func LoadVideosByQueryV2(query, name string, c common.Cacheable, api synq.ApiV2) (videos []synq.VideoV2, err error) {
-	return videos, errors.New("v2 query currently not implemented")
+	ok := LoadFromCache(name, c, &videos)
+	if ok {
+		return videos, nil
+	}
+	log.Printf("get all videos (filter by account '%s')\n", query)
+	videos, err = api.GetVideos(query)
+	if err != nil {
+		return videos, err
+	}
+	SaveToCache(name, c, videos)
+	return videos, err
 }
 
 func LoadVideo(id string, c common.Cacheable, api synq.Api) (video synq.Video, err error) {

--- a/helper/load.go
+++ b/helper/load.go
@@ -1,0 +1,85 @@
+package helper
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/SYNQfm/SYNQ-Golang/synq"
+	"github.com/SYNQfm/helpers/common"
+)
+
+func LoadFromCache(name string, c common.Cacheable, obj interface{}) bool {
+	cacheFile := c.GetCacheFile(name)
+	if cacheFile != "" {
+		if _, e := os.Stat(cacheFile); e == nil {
+			log.Printf("loading from cached file %s\n", cacheFile)
+			bytes, _ := ioutil.ReadFile(cacheFile)
+			json.Unmarshal(bytes, obj)
+			return true
+		}
+	}
+	return false
+}
+
+func SaveToCache(name string, c common.Cacheable, obj interface{}) bool {
+	cacheFile := c.GetCacheFile(name)
+	if cacheFile != "" {
+		data, _ := json.Marshal(obj)
+		ioutil.WriteFile(cacheFile, data, 0755)
+		return true
+	}
+	return false
+}
+
+func LoadVideosByQuery(query, name string, c common.Cacheable, api synq.Api) (videos []synq.Video, err error) {
+	ok := LoadFromCache(name, c, &videos)
+	if ok {
+		return videos, nil
+	}
+	log.Printf("querying '%s'\n", query)
+	videos, err = api.Query(query)
+	if err != nil {
+		return videos, err
+	}
+	SaveToCache(name, c, videos)
+	return videos, err
+}
+
+func LoadVideosByQueryV2(query, name string, c common.Cacheable, api synq.ApiV2) (videos []synq.VideoV2, err error) {
+	return videos, errors.New("v2 query currently not implemented")
+}
+
+func LoadVideo(id string, c common.Cacheable, api synq.Api) (video synq.Video, err error) {
+	ok := LoadFromCache(id, c, &video)
+	if ok {
+		video.Api = &api
+		return video, nil
+	}
+	// need to use the v1 api to get the raw video data
+	log.Printf("Getting video %s", id)
+	video, e := api.GetVideo(id)
+	if e != nil {
+		return video, e
+	}
+	SaveToCache(id, c, &video)
+	return video, nil
+}
+
+func LoadVideoV2(id string, c common.Cacheable, api synq.ApiV2) (video synq.VideoV2, err error) {
+	ok := LoadFromCache(id, c, &video)
+	if ok {
+		video.Api = &api
+		return video, nil
+	}
+	// need to use the v1 api to get the raw video data
+	log.Printf("Getting video %s", id)
+	video, e := api.GetVideo(id)
+	if e != nil {
+		return video, e
+	}
+	SaveToCache(id, c, video)
+	return video, nil
+}

--- a/helper/load_test.go
+++ b/helper/load_test.go
@@ -1,0 +1,55 @@
+package helper
+
+import (
+	"os"
+	"testing"
+
+	"github.com/SYNQfm/SYNQ-Golang/synq"
+	"github.com/SYNQfm/SYNQ-Golang/test_server"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	sampleDir = "../sample"
+	cacheDir  = "cache_dir"
+)
+
+var testAuth string
+
+type Cache struct {
+	Dir string
+}
+
+func setup() (synq.ApiV2, Cache) {
+	os.RemoveAll(cacheDir)
+	os.MkdirAll(cacheDir, 0755)
+	cache := Cache{Dir: cacheDir}
+	api := test_server.SetupServerAndApiV2(testAuth)
+	return api, cache
+}
+
+func (c Cache) GetCacheFile(name string) string {
+	return c.Dir + "/" + name + ".json"
+}
+
+func init() {
+	test_server.SetSampleDir(sampleDir)
+	testAuth = test_server.TEST_AUTH
+}
+
+func TestLoadVideo(t *testing.T) {
+	assert := require.New(t)
+	api, cache := setup()
+	v, e := LoadVideoV2(test_server.V2_VIDEO_ID, cache, api)
+	assert.Nil(e)
+	assert.Equal(test_server.V2_VIDEO_ID, v.Id)
+	cacheFile := cache.GetCacheFile(v.Id)
+	_, err := os.Stat(cacheFile)
+	assert.Nil(err)
+	// should avoid the call
+	api2 := synq.ApiV2{}
+	v2, e2 := LoadVideoV2(test_server.V2_VIDEO_ID, cache, api2)
+	assert.Nil(e2)
+	assert.Equal(v.Id, v2.Id)
+	assert.NotEmpty(v2.Api)
+}

--- a/helper/load_test.go
+++ b/helper/load_test.go
@@ -20,21 +20,23 @@ type Cache struct {
 	Dir string
 }
 
+func init() {
+	test_server.SetSampleDir(sampleDir)
+	testAuth = test_server.TEST_AUTH
+}
+
 func setup() (synq.ApiV2, Cache) {
 	os.RemoveAll(cacheDir)
 	os.MkdirAll(cacheDir, 0755)
 	cache := Cache{Dir: cacheDir}
-	api := test_server.SetupServerAndApiV2(testAuth)
+	api := synq.NewV2(testAuth)
+	url := test_server.SetupServer("v2")
+	api.SetUrl(url)
 	return api, cache
 }
 
 func (c Cache) GetCacheFile(name string) string {
 	return c.Dir + "/" + name + ".json"
-}
-
-func init() {
-	test_server.SetSampleDir(sampleDir)
-	testAuth = test_server.TEST_AUTH
 }
 
 func TestLoadVideo(t *testing.T) {

--- a/sample/video_list.json
+++ b/sample/video_list.json
@@ -1,0 +1,50 @@
+{
+  "data": [
+    {
+      "user_data": {
+        "type": "test",
+        "description": "test in postman"
+      },
+      "metadata": null,
+      "id": "9e9dc8c8-f705-41db-88da-b3034894deb9",
+      "assets": [
+        {
+          "video_id": "9e9dc8c8-f705-41db-88da-b3034894deb9",
+          "updated_at": "2017-11-16T16:37:14.547327Z",
+          "type": "mp4",
+          "state": "created",
+          "metadata": null,
+          "location": "https://s3.amazonaws.com/synq-jessica/uploads/01/82/01823629bcf24c34b714ae21e1a4647f/01823629bcf24c34b714ae21e1a4647f.mp4",
+          "id": "01823629-bcf2-4c34-b714-ae21e1a4647f",
+          "created_at": "2017-11-16T16:37:13.606310Z",
+          "account_id": ""
+        }
+      ],
+      "updated_at": "2017-11-14T23:43:10.540544Z",
+      "created_at": "2017-11-14T23:43:10.517985Z"
+    },
+    {
+      "user_data": {
+        "type": "test",
+        "description": "test in postman"
+      },
+      "metadata": null,
+      "id": "eee2bc43-e973-4f73-857d-7c0bb111a834",
+      "assets": [
+        {
+          "video_id": "eee2bc43-e973-4f73-857d-7c0bb111a834",
+          "updated_at": "2017-11-16T16:37:14.547327Z",
+          "type": "mp4",
+          "state": "created",
+          "metadata": null,
+          "location": "https://s3.amazonaws.com/synq-jessica/uploads/01/82/01823629bcf24c34b714ae21e1a4647f/eee2bc43e9734f73857d7c0bb111a834.mp4",
+          "id": "01823629-bcf2-4c34-b714-ae21e1a4647f",
+          "created_at": "2017-11-16T16:37:13.606310Z",
+          "account_id": ""
+        }
+      ],
+      "updated_at": "2017-11-14T23:43:10.540544Z",
+      "created_at": "2017-11-14T23:43:10.517985Z"
+    }
+  ]
+}

--- a/synq/api2.go
+++ b/synq/api2.go
@@ -20,6 +20,10 @@ type ApiV2 struct {
 	*BaseApi
 }
 
+type VideoList struct {
+	Videos []VideoV2 `json:"data"`
+}
+
 func (a ApiV2) Version() string {
 	return "v2"
 }
@@ -101,6 +105,28 @@ func (a *ApiV2) Create(body ...[]byte) (VideoV2, error) {
 	video = resp.Video
 	video.Api = a
 	return video, nil
+}
+
+func (a *ApiV2) GetVideos(accountId string) (videos []VideoV2, err error) {
+	var resp VideoList
+	path = "/videos"
+	if accountId != "" {
+		path = "/" + accountId + path
+	}
+	url := a.getBaseUrl() + path
+	req, err := a.makeRequest("GET", url, nil)
+	if err != nil {
+		return video, err
+	}
+	err = handleReq(a, req, &resp)
+	if err != nil {
+		return videos, err
+	}
+	for _, v := range resp.Videos {
+		v.Api = a
+		videos = append(videos, v)
+	}
+	return videos, nil
 }
 
 // Helper function to get details for a video, will create video object

--- a/synq/api2.go
+++ b/synq/api2.go
@@ -109,14 +109,14 @@ func (a *ApiV2) Create(body ...[]byte) (VideoV2, error) {
 
 func (a *ApiV2) GetVideos(accountId string) (videos []VideoV2, err error) {
 	var resp VideoList
-	path = "/videos"
+	path := "/videos"
 	if accountId != "" {
 		path = "/" + accountId + path
 	}
 	url := a.getBaseUrl() + path
 	req, err := a.makeRequest("GET", url, nil)
 	if err != nil {
-		return video, err
+		return videos, err
 	}
 	err = handleReq(a, req, &resp)
 	if err != nil {

--- a/synq/api2.go
+++ b/synq/api2.go
@@ -111,7 +111,7 @@ func (a *ApiV2) GetVideos(accountId string) (videos []VideoV2, err error) {
 	var resp VideoList
 	path := "/videos"
 	if accountId != "" {
-		path = "/" + accountId + path
+		path = "/accounts/" + accountId + path
 	}
 	url := a.getBaseUrl() + path
 	req, err := a.makeRequest("GET", url, nil)

--- a/synq/api2_test.go
+++ b/synq/api2_test.go
@@ -16,7 +16,6 @@ func init() {
 	testAssetId = test_server.ASSET_ID
 	testVideoIdV2 = test_server.V2_VIDEO_ID
 	testAuth = test_server.TEST_AUTH
-	test_server.SetSampleDir(sampleDir)
 }
 
 func setupTestApiV2(key string) ApiV2 {
@@ -28,7 +27,7 @@ func setupTestApiV2(key string) ApiV2 {
 
 func TestMakeReq2(t *testing.T) {
 	assert := require.New(t)
-	api := setupTestApiV2("fake")
+	api := test_server.SetupServerAndApiV2("fake")
 	body := strings.NewReader("")
 	req, err := api.makeRequest("POST", "url", body)
 	assert.Nil(err)
@@ -40,7 +39,7 @@ func TestMakeReq2(t *testing.T) {
 
 func TestCreate2(t *testing.T) {
 	assert := require.New(t)
-	api := setupTestApiV2("fake")
+	api := test_server.SetupServerAndApiV2("fake")
 	_, err := api.Create()
 	assert.NotNil(err)
 	api.SetKey(testAuth)
@@ -51,7 +50,7 @@ func TestCreate2(t *testing.T) {
 
 func TestGet2(t *testing.T) {
 	assert := require.New(t)
-	api := setupTestApiV2(testAuth)
+	api := test_server.SetupServerAndApiV2(testAuth)
 	_, err := api.GetVideo("")
 	assert.NotNil(err)
 	video, err := api.GetVideo(testVideoIdV2)
@@ -64,7 +63,7 @@ func TestGet2(t *testing.T) {
 
 func TestParseErrorV2(t *testing.T) {
 	assert := require.New(t)
-	api := setupTestApiV2(testAuth)
+	api := test_server.SetupServerAndApiV2(testAuth)
 	bytes := []byte{}
 	err := api.ParseError(404, bytes)
 	assert.Equal("404 Item not found", err.Error())

--- a/synq/api2_test.go
+++ b/synq/api2_test.go
@@ -10,11 +10,13 @@ import (
 
 var testAssetId string
 var testVideoIdV2 string
+var testVideoId2V2 string
 var testAuth string
 
 func init() {
 	testAssetId = test_server.ASSET_ID
 	testVideoIdV2 = test_server.V2_VIDEO_ID
+	testVideoId2V2 = test_server.V2_VIDEO_ID2
 	testAuth = test_server.TEST_AUTH
 }
 
@@ -59,6 +61,16 @@ func TestGet2(t *testing.T) {
 	assert.Len(video.Assets, 1)
 	assert.Equal(testAssetId, video.Assets[0].Id)
 	assert.NotNil(video.Api)
+}
+
+func TestGetVideos(t *testing.T) {
+	assert := require.New(t)
+	api := setupTestApiV2(testAuth)
+	videos, err := api.GetVideos("")
+	assert.Nil(err)
+	assert.Len(videos, 2)
+	assert.Equal(testVideoIdV2, videos[0].Id)
+	assert.Equal(testVideoId2V2, videos[1].Id)
 }
 
 func TestParseErrorV2(t *testing.T) {

--- a/synq/api2_test.go
+++ b/synq/api2_test.go
@@ -27,7 +27,7 @@ func setupTestApiV2(key string) ApiV2 {
 
 func TestMakeReq2(t *testing.T) {
 	assert := require.New(t)
-	api := test_server.SetupServerAndApiV2("fake")
+	api := setupTestApiV2("fake")
 	body := strings.NewReader("")
 	req, err := api.makeRequest("POST", "url", body)
 	assert.Nil(err)
@@ -39,7 +39,7 @@ func TestMakeReq2(t *testing.T) {
 
 func TestCreate2(t *testing.T) {
 	assert := require.New(t)
-	api := test_server.SetupServerAndApiV2("fake")
+	api := setupTestApiV2("fake")
 	_, err := api.Create()
 	assert.NotNil(err)
 	api.SetKey(testAuth)
@@ -50,7 +50,7 @@ func TestCreate2(t *testing.T) {
 
 func TestGet2(t *testing.T) {
 	assert := require.New(t)
-	api := test_server.SetupServerAndApiV2(testAuth)
+	api := setupTestApiV2(testAuth)
 	_, err := api.GetVideo("")
 	assert.NotNil(err)
 	video, err := api.GetVideo(testVideoIdV2)
@@ -63,7 +63,7 @@ func TestGet2(t *testing.T) {
 
 func TestParseErrorV2(t *testing.T) {
 	assert := require.New(t)
-	api := test_server.SetupServerAndApiV2(testAuth)
+	api := setupTestApiV2(testAuth)
 	bytes := []byte{}
 	err := api.ParseError(404, bytes)
 	assert.Equal("404 Item not found", err.Error())

--- a/synq/api_test.go
+++ b/synq/api_test.go
@@ -31,6 +31,7 @@ func init() {
 	testVideoId2V1 = test_server.VIDEO_ID2
 	testApiKeyV1 = test_server.API_KEY
 	uploadKey = test_server.UPLOAD_KEY
+	test_server.SetSampleDir(sampleDir)
 }
 
 func setupTestApi(key string, type_ ...string) Api {

--- a/synq/video.go
+++ b/synq/video.go
@@ -109,6 +109,10 @@ func (u Uploader) url() string {
 	return u["uploader_url"]
 }
 
+func (v Video) ID() string {
+	return v.Id
+}
+
 // Calls the /v1/video/details API to load Video object information
 func (v *Video) GetVideo() error {
 	form := url.Values{}

--- a/synq/video.go
+++ b/synq/video.go
@@ -109,10 +109,6 @@ func (u Uploader) url() string {
 	return u["uploader_url"]
 }
 
-func (v Video) ID() string {
-	return v.Id
-}
-
 // Calls the /v1/video/details API to load Video object information
 func (v *Video) GetVideo() error {
 	form := url.Values{}

--- a/test_server/synq.go
+++ b/test_server/synq.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+
+	"github.com/SYNQfm/SYNQ-Golang/synq"
 )
 
 var defaultSampleDir = "sample"
@@ -52,6 +54,13 @@ func LoadSample(name string, sampleDir ...string) (data []byte) {
 		log.Panicf("could not load sample file %s : '%s'", name, err.Error())
 	}
 	return data
+}
+
+func SetupServerAndApiV2(key string) synq.ApiV2 {
+	api := synq.NewV2(key)
+	url := SetupServer("v2")
+	api.SetUrl(url)
+	return api
 }
 
 func SetupServer(version ...string) string {

--- a/test_server/synq.go
+++ b/test_server/synq.go
@@ -30,6 +30,7 @@ const (
 	HTTP_NOT_FOUND    = `{"url": "http://docs.synq.fm/api/v1/errors/http_not_found","name": "http_not_found","message": "Not found."}`
 	V2_INVALID_AUTH   = `{"message" : "invalid auth"}`
 	V2_VIDEO_ID       = "9e9dc8c8-f705-41db-88da-b3034894deb9"
+	V2_VIDEO_ID2      = "eee2bc43-e973-4f73-857d-7c0bb111a834"
 	ASSET_ID          = "01823629-bcf2-4c34-b714-ae21e1a4647f"
 	TEST_AUTH         = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rlc3QuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU3MjE4MjFiM2ExYWFmYmUxNTlkZGE2NSIsImF1ZCI6InRESzZBdUF0QVc0ckFySzhOSTltMXdJRW5WQU9RcjUxIiwiZXhwIjoxNDkzNDM5NTExLCJpYXQiOjE0NjE4MTcxMTF9.29JkFxoHqCRPIH2wVbT-ZNIMBK8xXLwkjbLmyWxpquE"
 )

--- a/test_server/synq.go
+++ b/test_server/synq.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
-
-	"github.com/SYNQfm/SYNQ-Golang/synq"
 )
 
 var defaultSampleDir = "sample"
@@ -54,13 +52,6 @@ func LoadSample(name string, sampleDir ...string) (data []byte) {
 		log.Panicf("could not load sample file %s : '%s'", name, err.Error())
 	}
 	return data
-}
-
-func SetupServerAndApiV2(key string) synq.ApiV2 {
-	api := synq.NewV2(key)
-	url := SetupServer("v2")
-	api.SetUrl(url)
-	return api
 }
 
 func SetupServer(version ...string) string {


### PR DESCRIPTION
This used to be in the ext.synq.go, but should be moved to the SDK itself, as its all related to this.