### PR TITLE
fix bug preventing "PUTS" form working

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -110,7 +110,7 @@ func handleV2(api synq.ApiV2) {
 		log.Printf("getting video %s\n", vid)
 		video, err := api.GetVideo(vid)
 		handleError(err)
-		log.Printf(video.Display())
+		log.Println(video.Display())
 	default:
 		handleError(errors.New("unknown command '" + cli.Command + "'"))
 	}
@@ -140,7 +140,7 @@ func handleV1(api synq.Api) {
 		handleError(err)
 		log.Printf("Found %d videos\n", len(videos))
 		for _, video := range videos {
-			log.Printf(video.Display())
+			log.Println(video.Display())
 		}
 		os.Exit(0)
 	case "upload":
@@ -215,7 +215,7 @@ func handleV1(api synq.Api) {
 		err = errors.New("unknown command '" + cli.Command + "'")
 	}
 	handleError(err)
-	log.Printf(video.Display())
+	log.Println(video.Display())
 }
 
 func main() {

--- a/cli/main.go
+++ b/cli/main.go
@@ -111,6 +111,17 @@ func handleV2(api synq.ApiV2) {
 		video, err := api.GetVideo(vid)
 		handleError(err)
 		log.Println(video.Display())
+	case "update":
+		id := "4a15e1fc-a422-466d-8cad-677c1605983c"
+		video, _ := api.GetVideo(id)
+		log.Printf("Got video %s", video.Id)
+		video.CompletenessScore = 10.1
+		err := video.Update()
+		if err != nil {
+			log.Printf("Got error %s", err.Error)
+		} else {
+			log.Printf("Got video score %.1f\n", video.CompletenessScore)
+		}
 	default:
 		handleError(errors.New("unknown command '" + cli.Command + "'"))
 	}

--- a/synq/api2.go
+++ b/synq/api2.go
@@ -74,7 +74,7 @@ func (a *ApiV2) makeRequest(method string, url string, body io.Reader) (req *htt
 	if err != nil {
 		return req, err
 	}
-	if method == "POST" {
+	if method == "POST" || method == "PUT" {
 		if strings.Contains(url, "/login") {
 			req.Header.Add("content-type", "application/x-www-form-urlencoded")
 		} else {

--- a/synq/video2_test.go
+++ b/synq/video2_test.go
@@ -33,6 +33,8 @@ func TestVideoUpdate(t *testing.T) {
 	assert.Contains(string(video.Userdata), "test2")
 	reqs, vals := test_server.GetReqs()
 	assert.Len(reqs, 1)
+	req := reqs[0]
+	assert.Equal("application/json", req.Header.Get("Content-Type"))
 	assert.Len(vals, 1)
 	assert.Equal(`{"metadata":{"meta":"new"},"user_data":{"user":"new"},"completeness_score":95.4}`, vals[0].Get("body"))
 }


### PR DESCRIPTION
We weren't setting the content type right.  This means updates right now would not work properly.

Assets worked because it explicitly set the application/json

closes #14 