### PR TITLE
Adding content_id to asset metadata

### DIFF
--- a/metadata/synq_metadata.go
+++ b/metadata/synq_metadata.go
@@ -40,6 +40,7 @@ type ImageData struct {
 }
 
 type AkkaXMLAsset struct {
+  ContentId     string              `json:"content_id"`
   MetaData
   Images        []ImageData         `json:"images"`
   Rights        []VideoRights       `json:"rights"`


### PR DESCRIPTION
Adding "content_id" to the asset metadata object for Akka so we can keep track of the content_id (this would be the provider's id).