### PR TITLE
remove references to v1

### DIFF
--- a/helper/load.go
+++ b/helper/load.go
@@ -9,20 +9,6 @@ import (
 	"github.com/SYNQfm/helpers/common"
 )
 
-func LoadVideosByQuery(query, name string, c common.Cacheable, api synq.Api) (videos []synq.Video, err error) {
-	ok := common.LoadFromCache(name, c, &videos)
-	if ok {
-		return videos, nil
-	}
-	log.Printf("querying '%s'\n", query)
-	videos, err = api.Query(query)
-	if err != nil {
-		return videos, err
-	}
-	common.SaveToCache(name, c, videos)
-	return videos, err
-}
-
 // fow now, the query will be the account id
 func LoadVideosByAccount(accountId, name string, c common.Cacheable, api synq.ApiV2) (videos []synq.VideoV2, err error) {
 	ok := common.LoadFromCache(name, c, &videos)
@@ -51,22 +37,6 @@ func LoadRawVideosByAccount(accountId, name string, c common.Cacheable, api synq
 	}
 	common.SaveToCache(name, c, videos)
 	return videos, err
-}
-
-func LoadVideo(id string, c common.Cacheable, api synq.Api) (video synq.Video, err error) {
-	ok := common.LoadFromCache(id, c, &video)
-	if ok {
-		video.Api = &api
-		return video, nil
-	}
-	// need to use the v1 api to get the raw video data
-	log.Printf("Getting video v1 %s", id)
-	video, e := api.GetVideo(id)
-	if e != nil {
-		return video, e
-	}
-	common.SaveToCache(id, c, &video)
-	return video, nil
 }
 
 func LoadVideoV2(id string, c common.Cacheable, api synq.ApiV2) (video synq.VideoV2, err error) {

--- a/helper/load_test.go
+++ b/helper/load_test.go
@@ -24,7 +24,6 @@ type Cache struct {
 
 func init() {
 	testAuth = test_server.TEST_AUTH
-	testKey = test_server.API_KEY
 }
 
 func getCache() Cache {
@@ -42,37 +41,12 @@ func setup() (synq.ApiV2, Cache) {
 	return api, getCache()
 }
 
-func setupV1() (synq.Api, Cache) {
-	api := synq.New(testKey)
-	server := test_server.SetupServer(SYNQ_LEGACY_VERSION, sampleDir)
-	url := server.GetUrl()
-	api.SetUrl(url)
-	return api, getCache()
-}
-
 func (c Cache) GetCacheFile(name string) string {
 	return c.Dir + "/" + name + ".json"
 }
 
 func (c Cache) GetCacheAge() time.Duration {
 	return 24 * time.Hour
-}
-
-func TestLoadVideoV1(t *testing.T) {
-	assert := require.New(t)
-	api, cache := setupV1()
-	v, e := LoadVideo(test_server.VIDEO_ID, cache, api)
-	assert.Nil(e)
-	assert.Equal(test_server.VIDEO_ID, v.Id)
-	cacheFile := cache.GetCacheFile(v.Id)
-	_, err := os.Stat(cacheFile)
-	assert.Nil(err)
-	// should avoid the call
-	api2 := synq.Api{}
-	v2, e2 := LoadVideo(test_server.VIDEO_ID, cache, api2)
-	assert.Nil(e2)
-	assert.Equal(v.Id, v2.Id)
-	assert.NotEmpty(v2.Api)
 }
 
 func TestLoadVideo(t *testing.T) {
@@ -141,17 +115,6 @@ func TestLoadRawVideosByAccount(t *testing.T) {
 	videos, err := LoadRawVideosByAccount("", "to_save", cache, api)
 	assert.Nil(err)
 	assert.Len(videos, 2)
-	cacheFile := cache.GetCacheFile("to_save")
-	_, err = os.Stat(cacheFile)
-	assert.Nil(err)
-}
-
-func TestLoadVideosByQueryV1(t *testing.T) {
-	assert := require.New(t)
-	api, cache := setupV1()
-	videos, err := LoadVideosByQuery("", "to_save", cache, api)
-	assert.Nil(err)
-	assert.Len(videos, 3)
 	cacheFile := cache.GetCacheFile("to_save")
 	_, err = os.Stat(cacheFile)
 	assert.Nil(err)

--- a/helper/setup.go
+++ b/helper/setup.go
@@ -37,7 +37,6 @@ type ApiSetting struct {
 }
 
 type ApiSet struct {
-	V1    ApiSetting `json:"v1"`
 	V2    ApiSetting `json:"v2"`
 	ApiV2 synq.ApiV2 `json:"-"`
 }

--- a/helper/setup.go
+++ b/helper/setup.go
@@ -39,7 +39,6 @@ type ApiSetting struct {
 type ApiSet struct {
 	V1    ApiSetting `json:"v1"`
 	V2    ApiSetting `json:"v2"`
-	ApiV1 synq.Api   `json:"-"`
 	ApiV2 synq.ApiV2 `json:"-"`
 }
 
@@ -53,12 +52,6 @@ func (a ApiSetting) Configure(api synq.ApiF) {
 	if a.Url != "" {
 		api.SetUrl(a.Url)
 	}
-}
-
-func (a ApiSetting) SetupV1() synq.Api {
-	api := synq.NewV1(a.ApiKey)
-	a.Configure(api)
-	return api
 }
 
 func (a ApiSetting) SetupV2() synq.ApiV2 {
@@ -84,9 +77,6 @@ func (a ApiSetting) Valid() bool {
 }
 
 func (a *ApiSet) Setup() {
-	if a.V1.Valid() {
-		a.ApiV1 = a.V1.SetupV1()
-	}
 	if a.V2.Valid() {
 		a.ApiV2 = a.V2.SetupV2()
 	}
@@ -108,11 +98,6 @@ func LoadFromFile(file ...string) (*ApiSet, error) {
 		set.Setup()
 	}
 	return set, nil
-}
-
-func SetupSynq() synq.Api {
-	api := SetupSynqApi()
-	return api.(synq.Api)
 }
 
 func SetupSynqV2() synq.ApiV2 {
@@ -143,20 +128,10 @@ func SetupSynqApi(setup ...ApiSetup) (api synq.ApiF) {
 	}
 	if strings.Contains(config.Key, ".") || config.Version == SYNQ_VERSION {
 		api = synq.NewV2(config.Key)
-	} else {
-		api = synq.NewV1(config.Key)
+		if config.Url != "" {
+			api.SetUrl(config.Url)
+		}
 	}
-	if config.Url != "" {
-		api.SetUrl(config.Url)
-	}
-	return api
-}
-
-func SetupForTestV1() synq.Api {
-	server := test_server.SetupServer(SYNQ_LEGACY_VERSION)
-	url := server.GetUrl()
-	api := synq.NewV1(test_server.API_KEY)
-	api.SetUrl(url)
 	return api
 }
 

--- a/helper/setup_test.go
+++ b/helper/setup_test.go
@@ -2,9 +2,7 @@ package helper
 
 import (
 	"testing"
-	"time"
 
-	"github.com/SYNQfm/SYNQ-Golang/synq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,37 +19,9 @@ func TestGetSetup(t *testing.T) {
 	assert.Equal(SYNQ_VERSION, setup.Version)
 }
 
-func TestSetupSynq(t *testing.T) {
-	assert := assert.New(t)
-	api := SetupSynq()
-	assert.Equal(SYNQ_LEGACY_VERSION, api.Version())
-}
-
 func TestSetupSynqV2(t *testing.T) {
 	api2 := SetupSynqV2()
 	assert.Equal(t, SYNQ_VERSION, api2.Version())
-}
-
-func TestConfigure(t *testing.T) {
-	assert := require.New(t)
-	setting := ApiSetting{Url: "url", Timeout: 111, UploadTimeout: 555}
-	api := synq.NewV1("123")
-	setting.Configure(api)
-	assert.Equal(setting.Url, api.GetUrl())
-	assert.Equal(time.Duration(setting.Timeout)*time.Second, api.GetTimeout(""))
-	assert.Equal(time.Duration(setting.UploadTimeout)*time.Second, api.GetTimeout("upload"))
-}
-
-func TestSetup(t *testing.T) {
-	assert := require.New(t)
-	setting := ApiSetting{ApiKey: "123"}
-	set := ApiSet{V1: setting}
-	assert.Nil(set.ApiV1.BaseApi)
-	assert.Nil(set.ApiV2.BaseApi)
-	set.Setup()
-	assert.NotNil(set.ApiV1.BaseApi)
-	assert.Nil(set.ApiV2.BaseApi)
-	assert.Equal("123", set.ApiV1.GetKey())
 }
 
 func TestLoadFromFile(t *testing.T) {
@@ -60,10 +30,7 @@ func TestLoadFromFile(t *testing.T) {
 	assert.NotNil(err)
 	set, err := LoadFromFile(TEST_CRED_FILE)
 	assert.Nil(err)
-	assert.Equal("123", set.V1.ApiKey)
 	assert.Equal("456", set.V2.ApiKey)
-	assert.NotNil(set.ApiV1.BaseApi)
 	assert.NotNil(set.ApiV2.BaseApi)
-	assert.Equal("123", set.ApiV1.GetKey())
 	assert.Equal("456", set.ApiV2.GetKey())
 }


### PR DESCRIPTION
There were still remaining references to v1 which caused build errors. 