### PR TITLE
add Character field to Credit

### DIFF
--- a/metadata/synq_metadata.go
+++ b/metadata/synq_metadata.go
@@ -65,8 +65,9 @@ type VideoRights struct {
 }
 
 type Rating struct {
-	Country string `json:"country"`
+	Country string `json:"country,omitempty"`
 	Content string `json:"content"`
+	System  string `json:"system,omitempty"`
 }
 
 type MultiformData struct {

--- a/metadata/synq_metadata.go
+++ b/metadata/synq_metadata.go
@@ -33,8 +33,9 @@ type Series struct {
 }
 
 type Credit struct {
-	Name     string `json:"name"`
-	Function string `json:"role"`
+	Name      string `json:"name"`
+	Function  string `json:"role"`
+	Character string `json:"character,omitempty"`
 }
 
 type Language map[string]string


### PR DESCRIPTION
Tears of Steel (41101458-bc49-40db-badc-1b480831b79b) has it in the video metadata but it's not in the code. Probably not used by others? LevelK has this info. We can add it if the data is there but if not, can leave it empty and it is not added in Akka. 

Update: Also added system field in Rating.